### PR TITLE
[feat] Add support to skip arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ dd = DatasetDog("<API SERVER>", "<PROJECT ID>", "<API SECRET>")
 def api1(a: float = 1.0, b: float = 2.0) -> float:
     return a + b
 ```
-<<<<<<< HEAD
 
 - Skip recording sensitive arguments
 
@@ -27,10 +26,3 @@ def api1(a: float = 1.0, b: float = 2.0) -> float:
 def api1(a: float = 1.0, b: float = 2.0) -> float:
     return a + b
 ```
-
-## TODO
-- Documentation
-- Examples
-- Pypi
-=======
->>>>>>> master

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ python3 -m pip install git+https://github.com/vidursatija/dataset-dog-python.git
 ```
 
 ## Usage
-```python
+```python3
 from dataset_dog import DatasetDog
 
 
@@ -18,6 +18,14 @@ def api1(a: float = 1.0, b: float = 2.0) -> float:
     return a + b
 ```
 
+- Skip recording sensitive arguments
+
+```python3
+# say `b` is a sensitive argument, and we don't want to record it
+@dd.record_function(frequency=0.5, skip_args=["b"])
+def api1(a: float = 1.0, b: float = 2.0) -> float:
+    return a + b
+```
 
 ## TODO
 - Documentation


### PR DESCRIPTION
Add optional parameter to skip arguments

example:

```python3
@dd.record_function(frequency=0.5)
def api1(a: float = 1.0, b: float = 2.0) -> float:
    return a + b

@dd.record_function(frequency=0.5, skip_args=["b"])
def api1(a: float = 1.0, b: float = 2.0) -> float:
    return a + b
```